### PR TITLE
Update Platform Makefiles

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -61,6 +61,11 @@ jobs:
         dumpbin /dependents /exports ./build/make/bin/win-${{ env.TARGET_ARCH }}/CppCore.Test.exe
         dumpbin /dependents /exports ./build/make/bin/win-${{ env.TARGET_ARCH }}/CppCore.Debug.exe
 
+    # Test
+    - name: Test
+      if: matrix.arch == 'x64' || matrix.arch == 'x86'
+      run: ./build/make/bin/win-${{ env.TARGET_ARCH }}/CppCore.Test.exe
+
     # Upload
     - name: Upload
       uses: actions/upload-artifact@v3

--- a/build/make/platforms/linux-all-linux-arm.mk
+++ b/build/make/platforms/linux-all-linux-arm.mk
@@ -29,9 +29,9 @@ DISTDIR    = ../../dist/ubuntu-$(LSBREL)
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/linux-all-linux-arm64.mk
+++ b/build/make/platforms/linux-all-linux-arm64.mk
@@ -29,9 +29,9 @@ DISTDIR    = ../../dist/ubuntu-$(LSBREL)
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/linux-all-linux-x64.mk
+++ b/build/make/platforms/linux-all-linux-x64.mk
@@ -29,9 +29,9 @@ DISTDIR    = ../../dist/ubuntu-$(LSBREL)
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/linux-all-linux-x86.mk
+++ b/build/make/platforms/linux-all-linux-x86.mk
@@ -29,9 +29,9 @@ DISTDIR    = ../../dist/ubuntu-$(LSBREL)
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-all-ios-arm64.mk
+++ b/build/make/platforms/osx-all-ios-arm64.mk
@@ -30,7 +30,7 @@ ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
 CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
 CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto=thin -g -dead_strip
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -dead_strip
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-all-osx-arm64.mk
+++ b/build/make/platforms/osx-all-osx-arm64.mk
@@ -30,7 +30,7 @@ ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
 CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
 CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto=thin -g -dead_strip
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -dead_strip
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-all-osx-x64.mk
+++ b/build/make/platforms/osx-all-osx-x64.mk
@@ -56,7 +56,7 @@ ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
 CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
 CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto=thin -g -dead_strip
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -dead_strip
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-x64-android-arm.mk
+++ b/build/make/platforms/osx-x64-android-arm.mk
@@ -40,9 +40,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-x64-android-arm64.mk
+++ b/build/make/platforms/osx-x64-android-arm64.mk
@@ -40,9 +40,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-x64-android-x64.mk
+++ b/build/make/platforms/osx-x64-android-x64.mk
@@ -40,9 +40,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/osx-x64-android-x86.mk
+++ b/build/make/platforms/osx-x64-android-x86.mk
@@ -40,9 +40,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/win-all-win-arm64.mk
+++ b/build/make/platforms/win-all-win-arm64.mk
@@ -31,9 +31,9 @@ RCFLAGS    = -L0x0409 -NOLOGO
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-LINKFLAGS := $(LINKFLAGS) -flto -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
 LINKLIBS  := $(LINKLIBS) -llibcmt.lib
 else
 DEFINES   := $(DEFINES) -D_DEBUG

--- a/build/make/platforms/win-all-win-x64.mk
+++ b/build/make/platforms/win-all-win-x64.mk
@@ -31,9 +31,9 @@ RCFLAGS    = -L0x0409 -NOLOGO
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-LINKFLAGS := $(LINKFLAGS) -flto -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
 LINKLIBS  := $(LINKLIBS) -llibcmt.lib
 else
 DEFINES   := $(DEFINES) -D_DEBUG

--- a/build/make/platforms/win-all-win-x86.mk
+++ b/build/make/platforms/win-all-win-x86.mk
@@ -31,9 +31,9 @@ RCFLAGS    = -L0x0409 -NOLOGO
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections -Xclang -MT
-LINKFLAGS := $(LINKFLAGS) -flto -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections -Xclang -MT
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Xlinker /OPT:ref -Xlinker /OPT:icf -RELEASE
 LINKLIBS  := $(LINKLIBS) -llibcmt.lib
 else
 DEFINES   := $(DEFINES) -D_DEBUG

--- a/build/make/platforms/win-x64-android-arm.mk
+++ b/build/make/platforms/win-x64-android-arm.mk
@@ -43,9 +43,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/win-x64-android-arm64.mk
+++ b/build/make/platforms/win-x64-android-arm64.mk
@@ -43,9 +43,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/win-x64-android-x64.mk
+++ b/build/make/platforms/win-x64-android-x64.mk
@@ -43,9 +43,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3

--- a/build/make/platforms/win-x64-android-x86.mk
+++ b/build/make/platforms/win-x64-android-x86.mk
@@ -43,9 +43,9 @@ LINKLIBS   =
 # Debug vs. Release
 ifeq ($(MODE),release)
 DEFINES   := $(DEFINES) -DNDEBUG
-CXXFLAGS  := $(CXXFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-CFLAGS    := $(CFLAGS) -flto -O3 -ffunction-sections -fdata-sections
-LINKFLAGS := $(LINKFLAGS) -flto -Wl,--gc-sections
+CXXFLAGS  := $(CXXFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+CFLAGS    := $(CFLAGS) -flto=thin -O3 -g -ffunction-sections -fdata-sections
+LINKFLAGS := $(LINKFLAGS) -flto=thin -O3 -g -Wl,--gc-sections
 else
 DEFINES   := $(DEFINES) -D_DEBUG
 CXXFLAGS  := $(CXXFLAGS) -Og -g3


### PR DESCRIPTION
* Use `-flto=thin` on all platforms for release builds
* Generate debug info again for all release build (now lightweight, due to `-flto=thin`)
* Use `-O3` flag also in linker for release builds