### PR TITLE
Several changes for macOS and iOS

### DIFF
--- a/build/make/CppCore.Debug.mk
+++ b/build/make/CppCore.Debug.mk
@@ -131,7 +131,3 @@ clean:
 	$(call deletefiles,$(OBJDIR),*.res)
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTBIN))
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTPDB))
-	$(call deletefiles,$(DISTDIR),*.deb)
-	$(call deletefiles,$(DISTDIR),*.exe)
-	$(call deletefiles,$(DISTDIR),*.msixbundle)
-	$(call deletefiles,$(DISTDIR),*.pkg)

--- a/build/make/CppCore.Debug.mk
+++ b/build/make/CppCore.Debug.mk
@@ -64,10 +64,10 @@ endif
 ifeq ($(TARGET_OS),osx)
 OUTDIST   := $(DISTDIR)/$(NAME).app/Contents/MacOS/$(NAME)$(EXTBIN)
 DEFINES   := $(DEFINES)
-CXXFLAGS  := $(CXXFLAGS) -ObjC++
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
 CFLAGS    := $(CFLAGS)
 LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
-LINKLIBS  := $(LINKLIBS) -framework Cocoa
+LINKLIBS  := $(LINKLIBS) -framework AppKit
 RESO      := $(RESO)
 endif
 

--- a/build/make/CppCore.Debug.mk
+++ b/build/make/CppCore.Debug.mk
@@ -91,6 +91,16 @@ LINKLIBS  := $(LINKLIBS) -ldl
 RESO      := $(RESO)
 endif
 
+ifeq ($(TARGET_OS),ios)
+OUTDIST   := $(DISTDIR)/$(NAME)$(EXTBIN)
+DEFINES   := $(DEFINES)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
+CFLAGS    := $(CFLAGS)
+LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
+LINKLIBS  := $(LINKLIBS) -framework Foundation
+RESO      := $(RESO)
+endif
+
 ################################################################################################
 
 OBJS := $(patsubst %,$(OBJDIR)/%,$(OBJS))

--- a/build/make/CppCore.Example.Client.mk
+++ b/build/make/CppCore.Example.Client.mk
@@ -64,10 +64,10 @@ endif
 ifeq ($(TARGET_OS),osx)
 OUTDIST   := $(DISTDIR)/$(NAME).app/Contents/MacOS/$(NAME)$(EXTBIN)
 DEFINES   := $(DEFINES)
-CXXFLAGS  := $(CXXFLAGS)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
 CFLAGS    := $(CFLAGS)
 LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
-LINKLIBS  := $(LINKLIBS)
+LINKLIBS  := $(LINKLIBS) -framework AppKit
 RESO      := $(RESO)
 endif
 

--- a/build/make/CppCore.Example.Client.mk
+++ b/build/make/CppCore.Example.Client.mk
@@ -131,10 +131,6 @@ clean:
 	$(call deletefiles,$(OBJDIR),*.res)
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTBIN))
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTPDB))
-	$(call deletefiles,$(DISTDIR),*.deb)
-	$(call deletefiles,$(DISTDIR),*.exe)
-	$(call deletefiles,$(DISTDIR),*.msixbundle)
-	$(call deletefiles,$(DISTDIR),*.pkg)
 
 ################################################################################################
 

--- a/build/make/CppCore.Example.Client.mk
+++ b/build/make/CppCore.Example.Client.mk
@@ -91,6 +91,16 @@ LINKLIBS  := $(LINKLIBS) -ldl
 RESO      := $(RESO)
 endif
 
+ifeq ($(TARGET_OS),ios)
+OUTDIST   := $(DISTDIR)/$(NAME)$(EXTBIN)
+DEFINES   := $(DEFINES)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
+CFLAGS    := $(CFLAGS)
+LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
+LINKLIBS  := $(LINKLIBS) -framework Foundation
+RESO      := $(RESO)
+endif
+
 ################################################################################################
 
 OBJS := $(patsubst %,$(OBJDIR)/%,$(OBJS))

--- a/build/make/CppCore.Example.Server.mk
+++ b/build/make/CppCore.Example.Server.mk
@@ -92,6 +92,16 @@ LINKLIBS  := $(LINKLIBS) -ldl
 RESO      := $(RESO)
 endif
 
+ifeq ($(TARGET_OS),ios)
+OUTDIST   := $(DISTDIR)/$(NAME)$(EXTBIN)
+DEFINES   := $(DEFINES)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
+CFLAGS    := $(CFLAGS)
+LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
+LINKLIBS  := $(LINKLIBS) -framework Foundation
+RESO      := $(RESO)
+endif
+
 ################################################################################################
 
 OBJS := $(patsubst %,$(OBJDIR)/%,$(OBJS))

--- a/build/make/CppCore.Example.Server.mk
+++ b/build/make/CppCore.Example.Server.mk
@@ -65,10 +65,10 @@ endif
 ifeq ($(TARGET_OS),osx)
 OUTDIST   := $(DISTDIR)/$(NAME).app/Contents/MacOS/$(NAME)$(EXTBIN)
 DEFINES   := $(DEFINES)
-CXXFLAGS  := $(CXXFLAGS)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
 CFLAGS    := $(CFLAGS)
 LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
-LINKLIBS  := $(LINKLIBS)
+LINKLIBS  := $(LINKLIBS) -framework AppKit
 RESO      := $(RESO)
 endif
 

--- a/build/make/CppCore.Example.Server.mk
+++ b/build/make/CppCore.Example.Server.mk
@@ -132,11 +132,7 @@ clean:
 	$(call deletefiles,$(OBJDIR),*.res)
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTBIN))
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTPDB))
-	$(call deletefiles,$(DISTDIR),*.deb)
-	$(call deletefiles,$(DISTDIR),*.exe)
-	$(call deletefiles,$(DISTDIR),*.msixbundle)
-	$(call deletefiles,$(DISTDIR),*.pkg)
-	
+
 ################################################################################################
 
 include ./platforms/dist.mk

--- a/build/make/CppCore.Example.UI.mk
+++ b/build/make/CppCore.Example.UI.mk
@@ -131,11 +131,7 @@ clean:
 	$(call deletefiles,$(OBJDIR),*.res)
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTBIN))
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTPDB))
-	$(call deletefiles,$(DISTDIR),*.deb)
-	$(call deletefiles,$(DISTDIR),*.exe)
-	$(call deletefiles,$(DISTDIR),*.msixbundle)
-	$(call deletefiles,$(DISTDIR),*.pkg)
-	
+
 ################################################################################################
 
 include ./platforms/dist.mk

--- a/build/make/CppCore.Example.UI.mk
+++ b/build/make/CppCore.Example.UI.mk
@@ -91,6 +91,16 @@ LINKLIBS  := $(LINKLIBS) -ldl
 RESO      := $(RESO)
 endif
 
+ifeq ($(TARGET_OS),ios)
+OUTDIST   := $(DISTDIR)/$(NAME)$(EXTBIN)
+DEFINES   := $(DEFINES)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
+CFLAGS    := $(CFLAGS)
+LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
+LINKLIBS  := $(LINKLIBS) -framework Foundation
+RESO      := $(RESO)
+endif
+
 ################################################################################################
 
 OBJS := $(patsubst %,$(OBJDIR)/%,$(OBJS))

--- a/build/make/CppCore.Test.mk
+++ b/build/make/CppCore.Test.mk
@@ -90,6 +90,16 @@ LINKLIBS  := $(LINKLIBS) -ldl
 RESO      := $(RESO)
 endif
 
+ifeq ($(TARGET_OS),ios)
+OUTDIST   := $(DISTDIR)/$(NAME)$(EXTBIN)
+DEFINES   := $(DEFINES)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
+CFLAGS    := $(CFLAGS)
+LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
+LINKLIBS  := $(LINKLIBS) -framework Foundation
+RESO      := $(RESO)
+endif
+
 ################################################################################################
 
 OBJS := $(patsubst %,$(OBJDIR)/%,$(OBJS))

--- a/build/make/CppCore.Test.mk
+++ b/build/make/CppCore.Test.mk
@@ -130,7 +130,3 @@ clean:
 	$(call deletefiles,$(OBJDIR),*.res)
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTBIN))
 	$(call deletefiles,$(BINDIR),$(NAME)$(SUFFIX)$(EXTPDB))
-	$(call deletefiles,$(DISTDIR),*.deb)
-	$(call deletefiles,$(DISTDIR),*.exe)
-	$(call deletefiles,$(DISTDIR),*.msixbundle)
-	$(call deletefiles,$(DISTDIR),*.pkg)

--- a/build/make/CppCore.Test.mk
+++ b/build/make/CppCore.Test.mk
@@ -63,10 +63,10 @@ endif
 ifeq ($(TARGET_OS),osx)
 OUTDIST   := $(DISTDIR)/$(NAME).app/Contents/MacOS/$(NAME)$(EXTBIN)
 DEFINES   := $(DEFINES)
-CXXFLAGS  := $(CXXFLAGS)
+CXXFLAGS  := $(CXXFLAGS) -fdeclspec -ObjC++
 CFLAGS    := $(CFLAGS)
 LINKFLAGS := $(LINKFLAGS) -Wl,-object_path_lto,$(OBJDIR)/lto.o
-LINKLIBS  := $(LINKLIBS)
+LINKLIBS  := $(LINKLIBS) -framework AppKit
 RESO      := $(RESO)
 endif
 

--- a/include/CppCore/Root.h
+++ b/include/CppCore/Root.h
@@ -614,11 +614,17 @@
 #elif defined(CPPCORE_OS_OSX)
 #include <pwd.h>
 #include <mach-o/dyld.h>
+#if defined(__OBJC__)
+#include <Foundation/Foundation.h>
+#endif
 #elif defined(CPPCORE_OS_ANDROID)
 #include <pwd.h>
 #elif defined(CPPCORE_OS_IPHONE)
 #include <pwd.h>
 #include <mach-o/dyld.h>
+#if defined(__OBJC__)
+#include <Foundation/Foundation.h>
+#endif
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -754,11 +760,19 @@ static_assert(sizeof(double) == 8U);
 
 // Constants
 #define TWOPI         (2.0*M_PI)
+
 #define ISZERO(a, e)  (((a) > -e) & ((a) < e))
 #define SIGN(a)       (((a) > 0) ? 1 : (((a) < 0) ? -1 : 0))
+
+#ifndef MAX
 #define MAX(a,b)      ((a) >= (b) ? (a) : (b))
+#endif
+#ifndef MIN
 #define MIN(a,b)      ((a) <= (b) ? (a) : (b))
+#endif
+#ifndef ABS
 #define ABS(a)        ((a) < 0 ? -(a) : (a))
+#endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/CppCore/System.h
+++ b/include/CppCore/System.h
@@ -62,6 +62,9 @@ namespace CppCore
          #if defined(CPPCORE_OS_WINDOWS)
             const char* p = ::getenv("USERPROFILE");
             return p ? path(p) : path();
+         #elif defined(CPPCORE_OS_OSX) || defined(CPPCORE_OS_IPHONE)
+            NSString* s = NSHomeDirectory();
+            return path([s UTF8String]);
          #else
             struct passwd* pw = ::getpwuid(::getuid());
             return path(pw->pw_dir);


### PR DESCRIPTION
**MACOS + iOS**
* Use sandbox aware `NSHomeDirectory()` in `System.h`
* Include `Foundation.h` by default and link with `-framework Foundation`

**ALL**
* Don't delete `make dist` outputs on `make clean`