### PR TITLE
Improve bytedup() in BitOps.h and use in Block.h

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Cross-Compile Support
     - name: Cross-Compile Support
-      uses: cyberjunk/gha-ubuntu-cross@v2
+      uses: cyberjunk/gha-ubuntu-cross@v3
       if: matrix.arch != 'amd64'
       with:
         arch: ${{ matrix.arch }}

--- a/include/CppCore/BitOps.h
+++ b/include/CppCore/BitOps.h
@@ -2914,9 +2914,9 @@ namespace CppCore
       const __m256i dup256 = CppCore::bytedup256(v);
       const __m512i dup512 = CppCore::bytedup512(v);
       CPPCORE_CHUNK_PROCESS512_X(x, UINT, true,
-         *px512 = dup512;,
-         *px256 = dup256; ,
-         *px128 = dup128; ,
+         CPPCORE_CHUNK_STORE512(UINT, px512, dup512); ,
+         CPPCORE_CHUNK_STORE256(UINT, px256, dup256);,
+         CPPCORE_CHUNK_STORE128(UINT, px128, dup128);,
          *px64  = dup64; ,
          *px32  = dup32; ,
          *px16  = dup16; ,
@@ -2925,8 +2925,8 @@ namespace CppCore
       const __m128i dup128 = CppCore::bytedup128(v);
       const __m256i dup256 = CppCore::bytedup256(v);
       CPPCORE_CHUNK_PROCESS256_X(x, UINT, true,
-         *px256 = dup256; ,
-         *px128 = dup128; ,
+         CPPCORE_CHUNK_STORE256(UINT, px256, dup256); ,
+         CPPCORE_CHUNK_STORE128(UINT, px128, dup128); ,
          *px64  = dup64; ,
          *px32  = dup32; ,
          *px16  = dup16; ,
@@ -2934,7 +2934,7 @@ namespace CppCore
    #elif defined(CPPCORE_CPUFEAT_SSE2)
       const __m128i dup128 = CppCore::bytedup128(v);
       CPPCORE_CHUNK_PROCESS128_X(x, UINT, true,
-         *px128 = dup128; ,
+         CPPCORE_CHUNK_STORE128(UINT, px128, dup128); ,
          *px64  = dup64; ,
          *px32  = dup32; ,
          *px16  = dup16; ,

--- a/include/CppCore/Block.h
+++ b/include/CppCore/Block.h
@@ -38,7 +38,7 @@ namespace CppCore
       /// </summary>
       INLINE void set(const uint8_t v) 
       {
-         Memory::set8(u8, N8, v);
+         CppCore::bytedup(v, *(T*)this);
       }
 
       /// <summary>
@@ -90,23 +90,6 @@ namespace CppCore
    class Block16x : public Block<T, SIZE>
    {
       static_assert(SIZE % 2 == 0);
-
-   public:
-      /// <summary>
-      /// Sets all 16 Bit chunks to 16-Bit v.
-      /// </summary>
-      INLINE void set(const uint16_t v)
-      {
-         Memory::set16(this->u16, this->N16, v);
-      }
-
-      /// <summary>
-      /// Sets all 16 Bit chunks to duplicated 8-Bit v.
-      /// </summary>
-      INLINE void set(const uint8_t v)
-      {
-         set(CppCore::bytedup16(v));
-      }
    };
 
    /// <summary>
@@ -118,22 +101,6 @@ namespace CppCore
       static_assert(SIZE % 4 == 0);
 
    public:
-      /// <summary>
-      /// Sets all 32 Bit chunks to 32-Bit v.
-      /// </summary>
-      INLINE void set(const uint32_t v)
-      {
-         Memory::set32(this->u32, this->N32, v);
-      }
-      
-      /// <summary>
-      /// Sets all 32 Bit chunks to duplicated 8-Bit v.
-      /// </summary>
-      INLINE void set(const uint8_t v)
-      {
-         set(CppCore::bytedup32(v));
-      }
-
       /// <summary>
       /// Flips endianess of all 32-Bit chunks.
       /// </summary>
@@ -154,30 +121,6 @@ namespace CppCore
       static_assert(SIZE % 8 == 0);
 
    public:
-      /// <summary>
-      /// Sets all 64 Bit chunks to v.
-      /// </summary>
-      INLINE void set(const uint64_t v)
-      {
-         Memory::set64(this->u64, this->N64, v);
-      }
-
-      /// <summary>
-      /// Sets all 64 Bit chunks to duplicated 32-Bit v.
-      /// </summary>
-      INLINE void set(const uint32_t v)
-      {
-         set((uint64_t)v | ((uint64_t)v << 32));
-      }
-
-      /// <summary>
-      /// Sets all 64 Bit chunks to duplicated 8-Bit v.
-      /// </summary>
-      INLINE void set(const uint8_t v)
-      {
-         set(CppCore::bytedup64(v));
-      }
-
       /// <summary>
       /// Flips endianess of all 64-Bit chunks.
       /// </summary>


### PR DESCRIPTION
* Adds `bytedup128()`, `bytedup256()` and `bytedup512()` operations for SSE/AVX/AVX512 to `BitOps.h`
* Improves `bytedup()` template function for arbitrary size in `BitOps.h` operating in larger 128/256/512 chunks
* Uses improved `bytedup()` from `BitOps.h` in `Block.h`
* Use `gha-ubuntu-cross@v3`