### PR TITLE
Improve Memory.h

### DIFF
--- a/include/CppCore.Test/Memory.h
+++ b/include/CppCore.Test/Memory.h
@@ -643,6 +643,26 @@ namespace CppCore { namespace Test
             return false;
          return true;
       }
+      INLINE static bool copybackwards()
+      {
+         const size_t n512 = 4;
+         const size_t n256 = 1;
+         const size_t n128 = 1;
+         const size_t n64  = 1;
+         const size_t n32  = 1;
+         const size_t n16  = 1;
+         const size_t n8   = 1;
+         const size_t num  = n512*64 + n256*32 + n128*16 + n64*8 + n32*4 + n16*2 + n8;
+         CPPCORE_ALIGN64 char src[num];
+         CPPCORE_ALIGN64 char dst[num];
+         Random::Std::Int32 rnd;
+         for (size_t i = 0; i < num; i++)
+            src[i] = rnd.next() & 0xFF;
+         CppCore::Memory::copybackwards(dst, src, num);
+         if (0 != ::memcmp(src, dst, num))
+            return false;
+         return true;
+      }
       INLINE static bool streamcopy128()
       {
       #if defined(CPPCORE_CPUFEAT_SSE2)
@@ -2361,6 +2381,7 @@ namespace CppCore { namespace Test { namespace VS {
       TEST_METHOD(COPY256)              { Assert::AreEqual(true, CppCore::Test::Memory::copy256()); }
       TEST_METHOD(COPY512)              { Assert::AreEqual(true, CppCore::Test::Memory::copy512()); }
       TEST_METHOD(COPY)                 { Assert::AreEqual(true, CppCore::Test::Memory::copy()); }
+      TEST_METHOD(COPYBACKWARDS)        { Assert::AreEqual(true, CppCore::Test::Memory::copybackwards()); }
       TEST_METHOD(STREAMCOPY128)        { Assert::AreEqual(true, CppCore::Test::Memory::streamcopy128()); }
       TEST_METHOD(STREAMCOPY128x1)      { Assert::AreEqual(true, CppCore::Test::Memory::streamcopy128x1()); }
       TEST_METHOD(STREAMCOPY128x2)      { Assert::AreEqual(true, CppCore::Test::Memory::streamcopy128x2()); }

--- a/include/CppCore/Containers/Array.h
+++ b/include/CppCore/Containers/Array.h
@@ -105,13 +105,16 @@ namespace CppCore
             const size_t NLEN = LEN-n;
             if (idx < LEN && n <= idx)
             {
-               // TODO: Implement FLATCOPY
                mLength = NLEN;
                T* psrc = &thiss().mData[idx];
                T* pdst = &thiss().mData[idx-n];
-               T* pend = &thiss().mData[LEN];
-               while (psrc < pend)
-                  *pdst++ = *psrc++;
+               if constexpr (FLATCOPY)
+                  Memory::copy(pdst, psrc, (LEN-idx)*sizeof(T));
+               else {
+                  const T* pend = &thiss().mData[LEN];
+                  while (psrc < pend)
+                     *pdst++ = *psrc++;
+               }
                return true;
             }
             else
@@ -128,13 +131,19 @@ namespace CppCore
             const size_t NLEN = LEN+n;
             if (idx < LEN && NLEN <= thiss().size())
             {
-               // TODO: Implement FLATCOPY
                mLength = NLEN;
-               T* psrc = &thiss().mData[LEN-1];
-               T* pdst = &thiss().mData[NLEN-1];
-               T* pend = &thiss().mData[idx];
-               while (psrc >= pend)
-                  *pdst-- = *psrc--;
+               if constexpr (FLATCOPY) {
+                  T* psrc = &thiss().mData[idx];
+                  T* pdst = &thiss().mData[idx+n];
+                  Memory::copybackwards(pdst, psrc, (LEN-idx)*sizeof(T));
+               }
+               else {
+                  T* psrc = &thiss().mData[LEN-1];
+                  T* pdst = &thiss().mData[NLEN-1];
+                  T* pend = &thiss().mData[idx];
+                  while (psrc >= pend)
+                     *pdst-- = *psrc--;
+               }
                return true;
             }
             else

--- a/include/CppCore/Memory.h
+++ b/include/CppCore/Memory.h
@@ -3,6 +3,49 @@
 #include <CppCore/Root.h>
 #include <CppCore/Math/Util.h>
 
+#define CPPCORE_MEMORY_SWITCH_LEN15(len, op64, op32, op16, op8) \
+  switch ((len)) {                                           \
+  case 15: { { op64; } { op32; } { op16; } { op8; } } break; \
+  case 14: { { op64; } { op32; } { op16; }          } break; \
+  case 13: { { op64; } { op32; }           { op8; } } break; \
+  case 12: { { op64; } { op32; }                    } break; \
+  case 11: { { op64; }           { op16; } { op8; } } break; \
+  case 10: { { op64; }           { op16; }          } break; \
+  case 9:  { { op64; }                     { op8; } } break; \
+  case 8:  { { op64; }                              } break; \
+  case 7:  {           { op32; } { op16; } { op8; } } break; \
+  case 6:  {           { op32; } { op16; }          } break; \
+  case 5:  {           { op32; }           { op8; } } break; \
+  case 4:  {           { op32; }                    } break; \
+  case 3:  {                     { op16; } { op8; } } break; \
+  case 2:  {                     { op16; }          } break; \
+  case 1:  {                               { op8; } } break; \
+  default:                                            break; \
+  };
+
+#define CPPCORE_MEMORY_PROCESS_512(len, op512, op256, op128, op64, op32, op16, op8) \
+  while (len >= 64U) { \
+    len -= 64U;        \
+    op512;             \
+  }                    \
+  if (len >= 32U) {    \
+    len -= 32U;        \
+    op256;             \
+  }                    \
+  if (len >= 16U) {    \
+    len -= 16U;        \
+    op128;             \
+  }                    \
+  CPPCORE_MEMORY_SWITCH_LEN15(len, op64, op32, op16, op8)
+
+#define CPPCORE_MEMORY_PROCESS_256(len,                                           op256,                op128,      op64, op32, op16, op8) \
+        CPPCORE_MEMORY_PROCESS_512(len, op256;op256;,                             op256,                op128,      op64, op32, op16, op8)
+#define CPPCORE_MEMORY_PROCESS_128(len,                                                                 op128,      op64, op32, op16, op8) \
+        CPPCORE_MEMORY_PROCESS_512(len, op128;op128;op128;op128;,                 op128;op128;,         op128,      op64, op32, op16, op8)
+#define CPPCORE_MEMORY_PROCESS_64( len,                                                                             op64, op32, op16, op8) \
+        CPPCORE_MEMORY_PROCESS_512(len, op64;op64;op64;op64;op64;op64;op64;op64;, op64;op64;op64;op64;, op64;op64;, op64, op32, op16, op8)
+
+
 namespace CppCore
 {
    /// <summary>
@@ -1212,107 +1255,41 @@ namespace CppCore
       /// Copies any sized memory with any alignment.
       /// Consider using optimized copyXY() or streamcopyXY() for special cases instead.
       /// </summary>
-      INLINE static void copy(void* dstmem, const void* srcmem, const size_t len)
+      INLINE static void copy(void* dstmem, const void* srcmem, size_t len)
       {
-         char*       memd = (char*)dstmem;
-         char*       mems = (char*)srcmem;
-         const char*  end = memd + len;
-         while (memd + 64U <= end)
-         {
-         #if defined(CPPCORE_CPUFEAT_AVX512F)
-            _mm512_storeu_si512((__m512i*)memd, _mm512_loadu_si512((__m512i*)mems)); memd += 64U; mems += 64U;
-         #elif defined(CPPCORE_CPUFEAT_AVX)
-            _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems)); memd += 32U; mems += 32U;
-            _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems)); memd += 32U; mems += 32U;
-         #elif defined(CPPCORE_CPUFEAT_SSE2)
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-         #elif defined(CPPCORE_CPU_64BIT)
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-         #else
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-         #endif
-         }
-         if (memd + 32U <= end)
-         {
-         #if defined(CPPCORE_CPUFEAT_AVX)
-            _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems)); memd += 32U; mems += 32U;
-         #elif defined(CPPCORE_CPUFEAT_SSE2)
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-         #elif defined(CPPCORE_CPU_64BIT)
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-         #else
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-         #endif
-         }
-         if (memd + 16U <= end)
-         {
-         #if defined(CPPCORE_CPUFEAT_SSE2)
-            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;
-         #elif defined(CPPCORE_CPU_64BIT)
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-         #else
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-         #endif
-         }
-         if (memd + 8U <= end)
-         {
-         #if defined(CPPCORE_CPU_64BIT)
-            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;
-         #else
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-         #endif
-         }
-         if (memd + 4U <= end)
-         {
-            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;
-         }
-         if (memd + 2U <= end)
-         {
-            *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;
-         }
-         if (memd < end)
-            *((uint8_t*)memd) = *((uint8_t*)mems);
+         char* memd = (char*)dstmem;
+         char* mems = (char*)srcmem;
+      #if defined(CPPCORE_CPUFEAT_AVX512F)
+         CPPCORE_MEMORY_PROCESS_512(len,
+            _mm512_storeu_si512((__m512i*)memd, _mm512_loadu_si512((__m512i*)mems)); memd += 64U; mems += 64U;,
+            _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems)); memd += 32U; mems += 32U;, 
+            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;, 
+            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;, 
+            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;, 
+            *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;, 
+            *((uint8_t*) memd) = *((uint8_t*) mems); memd += 1U; mems += 1U;);
+      #elif defined(CPPCORE_CPUFEAT_AVX)
+         CPPCORE_MEMORY_PROCESS_256(len, 
+            _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems)); memd += 32U; mems += 32U; , 
+            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;, 
+            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;, 
+            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;, 
+            *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;, 
+            *((uint8_t*) memd) = *((uint8_t*) mems); memd += 1U; mems += 1U;);
+      #elif defined(CPPCORE_CPUFEAT_SSE2)
+         CPPCORE_MEMORY_PROCESS_128(len, 
+            _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems)); memd += 16U; mems += 16U;, 
+            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;, 
+            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;, 
+            *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;, 
+            *((uint8_t*) memd) = *((uint8_t*) mems); memd += 1U; mems += 1U;);
+      #else
+         CPPCORE_MEMORY_PROCESS_64(len, 
+            *((uint64_t*)memd) = *((uint64_t*)mems); memd += 8U; mems += 8U;, 
+            *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;, 
+            *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;, 
+            *((uint8_t*) memd) = *((uint8_t*) mems); memd += 1U; mems += 1U;);
+      #endif
       }
 
       ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/CppCore/Memory.h
+++ b/include/CppCore/Memory.h
@@ -1265,7 +1265,7 @@ namespace CppCore
 #endif
 
       /// <summary>
-      /// Copies any sized memory with any alignment.
+      /// Copies any sized memory with any alignment starting from front.
       /// Consider using optimized copyXY() or streamcopyXY() for special cases instead.
       /// </summary>
       INLINE static void copy(void* dstmem, const void* srcmem, size_t len)
@@ -1302,6 +1302,46 @@ namespace CppCore
             *((uint32_t*)memd) = *((uint32_t*)mems); memd += 4U; mems += 4U;, 
             *((uint16_t*)memd) = *((uint16_t*)mems); memd += 2U; mems += 2U;, 
             *((uint8_t*) memd) = *((uint8_t*) mems); memd += 1U; mems += 1U;);
+      #endif
+      }
+
+      /// <summary>
+      /// Copies any sized memory with any alignment starting from back.
+      /// </summary>
+      INLINE static void copybackwards(void* dstmem, const void* srcmem, size_t len)
+      {
+         char* memd = (char*)dstmem + len;
+         char* mems = (char*)srcmem + len;
+      #if defined(CPPCORE_CPUFEAT_AVX512F)
+         CPPCORE_MEMORY_PROCESS_512(len,
+            memd -= 64U; mems -= 64U; _mm512_storeu_si512((__m512i*)memd, _mm512_loadu_si512((__m512i*)mems));,
+            memd -= 32U; mems -= 32U; _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems));,
+            memd -= 16U; mems -= 16U; _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems));,
+            memd -=  8U; mems -=  8U; *((uint64_t*)memd) = *((uint64_t*)mems);,
+            memd -=  4U; mems -=  4U; *((uint32_t*)memd) = *((uint32_t*)mems);,
+            memd -=  2U; mems -=  2U; *((uint16_t*)memd) = *((uint16_t*)mems);, 
+            memd -=  1U; mems -=  1U; *((uint8_t*) memd) = *((uint8_t*) mems);)
+      #elif defined(CPPCORE_CPUFEAT_AVX)
+         CPPCORE_MEMORY_PROCESS_256X2(len, 
+            memd -= 32U; mems -= 32U; _mm256_storeu_si256((__m256i*)memd, _mm256_loadu_si256((__m256i*)mems));,
+            memd -= 16U; mems -= 16U; _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems));,
+            memd -=  8U; mems -=  8U; *((uint64_t*)memd) = *((uint64_t*)mems);,
+            memd -=  4U; mems -=  4U; *((uint32_t*)memd) = *((uint32_t*)mems);,
+            memd -=  2U; mems -=  2U; *((uint16_t*)memd) = *((uint16_t*)mems);,
+            memd -=  1U; mems -=  1U; *((uint8_t*) memd) = *((uint8_t*) mems);)
+      #elif defined(CPPCORE_CPUFEAT_SSE2)
+         CPPCORE_MEMORY_PROCESS_128X4(len, 
+            memd -= 16U; mems -= 16U; _mm_storeu_si128((__m128i*)memd, _mm_loadu_si128((__m128i*)mems));,
+            memd -=  8U; mems -=  8U; *((uint64_t*)memd) = *((uint64_t*)mems);,
+            memd -=  4U; mems -=  4U; *((uint32_t*)memd) = *((uint32_t*)mems);,
+            memd -=  2U; mems -=  2U; *((uint16_t*)memd) = *((uint16_t*)mems);,
+            memd -=  1U; mems -=  1U; *((uint8_t*) memd) = *((uint8_t*) mems);)
+      #else
+         CPPCORE_MEMORY_PROCESS_64X8(len, 
+            memd -= 8U; mems -= 8U; *((uint64_t*)memd) = *((uint64_t*)mems);,
+            memd -= 4U; mems -= 4U; *((uint32_t*)memd) = *((uint32_t*)mems);,
+            memd -= 2U; mems -= 2U; *((uint16_t*)memd) = *((uint16_t*)mems);,
+            memd -= 1U; mems -= 1U; *((uint8_t*) memd) = *((uint8_t*) mems);)
       #endif
       }
 

--- a/include/CppCore/Memory.h
+++ b/include/CppCore/Memory.h
@@ -28,18 +28,9 @@
 // decreases len in 64 byte steps executing one op512 each time
 // then handles the 0-63 remaining bytes using op256 to op8
 #define CPPCORE_MEMORY_PROCESS_512(len, op512, op256, op128, op64, op32, op16, op8) \
-  while (len >= 64U) { \
-    len -= 64U;        \
-    op512;             \
-  }                    \
-  if (len >= 32U) {    \
-    len -= 32U;        \
-    op256;             \
-  }                    \
-  if (len >= 16U) {    \
-    len -= 16U;        \
-    op128;             \
-  }                    \
+  while (len >= 64U) { len -= 64U; op512; }               \
+  if    (len >= 32U) { len -= 32U; op256; }               \
+  if    (len >= 16U) { len -= 16U; op128; }               \
   CPPCORE_MEMORY_SWITCH_LEN15(len, op64, op32, op16, op8)
 
 // decreases len in 64 byte steps executing two op256 each time

--- a/src/CppCore.Test/Test.cpp
+++ b/src/CppCore.Test/Test.cpp
@@ -392,6 +392,7 @@ int main()
    TEST(CppCore::Test::Memory::copy256,                "copy256:                ", std::endl);
    TEST(CppCore::Test::Memory::copy512,                "copy512:                ", std::endl);
    TEST(CppCore::Test::Memory::copy,                   "copy:                   ", std::endl);
+   TEST(CppCore::Test::Memory::copybackwards,          "copybackwards:          ", std::endl);
    TEST(CppCore::Test::Memory::streamcopy128,          "streamcopy128:          ", std::endl);
    TEST(CppCore::Test::Memory::streamcopy128x1,        "streamcopy128x1:        ", std::endl);
    TEST(CppCore::Test::Memory::streamcopy128x2,        "streamcopy128x2:        ", std::endl);


### PR DESCRIPTION
* Improves `Memory::copy()`
* Adds `Memory::copybackwards()`
* Use both in `FLATCOPY` cases of Array class