### PR TITLE
Improve umul()

### DIFF
--- a/include/CppCore/Math/Util.h
+++ b/include/CppCore/Math/Util.h
@@ -2142,8 +2142,11 @@ namespace CppCore
                *rp = k;
          }
       }
-      else if constexpr (sizeof(UINT1) % 4 == 0 && sizeof(UINT2) % 4 == 0 && sizeof(UINT3) % 4 == 0)
+      else if
+   #else
+      if
    #endif
+         constexpr (sizeof(UINT1) % 4 == 0 && sizeof(UINT2) % 4 == 0 && sizeof(UINT3) % 4 == 0)
       {
          // 32/64-Bit CPU and Multiples of 32-Bit
          constexpr size_t NA = sizeof(UINT1) / 4;

--- a/include/CppCore/Math/Util.h
+++ b/include/CppCore/Math/Util.h
@@ -2192,7 +2192,7 @@ namespace CppCore
       else if constexpr (sizeof(UINT1) < 4) { umul<size_t, UINT2, UINT3>((size_t)a, b, r); }
       else if constexpr (sizeof(UINT2) < 4) { umul<UINT1, size_t, UINT3>(a, (size_t)b, r); }
       else if constexpr (sizeof(UINT3) < 4) { size_t t; umul<UINT1, UINT2, size_t>(a, b, t); r=(UINT3)t; }
-      else static_assert(false);
+      else throw;
    }
 
    /// <summary>


### PR DESCRIPTION
Add support for `uint8_t` and `uint16_t` types as arguments by extending them to `size_t`